### PR TITLE
[Add]MonoBehaviour用のシングルトンクラス

### DIFF
--- a/Assets/Scripts/Utility.meta
+++ b/Assets/Scripts/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 139f3b17a12c847b297f87424ee0010b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/MonoSingleton.cs
+++ b/Assets/Scripts/Utility/MonoSingleton.cs
@@ -1,0 +1,69 @@
+using System;
+using UnityEngine;
+
+public abstract class MonoSingleton<T> :MonoBehaviour where T: MonoSingleton<T>
+{
+    /// <summary>
+        /// 唯一のインスタンス
+        /// </summary>
+        private static T instance;
+
+        /// <summary>
+        /// シングルトンなインスタンスを取得
+        /// </summary>
+        /// <exception cref="Exception"></exception>
+        public static T Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    // instanceがnullの場合、唯一のインスタンスを探す
+
+                    // シーンに存在する全てのTのインスタンスを探す
+                    var instances = FindObjectsOfType<T>();
+                    
+                    // 見つけたTのインスタンスの数で場合わけ
+                    instance = instances.Length switch
+                    {
+                        // インスタンスが存在しない場合、Resources内のプレハブを探す
+                        0 => throw new Exception($"{typeof(T)}のインスタンスがシーン上に存在しません。"),
+                        
+                        // 唯一である場合、それを返す
+                        1 => instances[0],
+                        
+                        // 複数ある場合、シングルトンの制約に反しているため例外を投げる
+                        _ => throw new Exception($"{typeof(T)}のインスタンスがシーン上に複数存在します。")
+                    };
+
+                    // 見つけた唯一のインスタンスを返す
+                    instance.BeforeFirstGetterCalling();
+                }
+
+                return instance;
+            }
+        }
+
+        /// <summary>
+        /// 初めてインスタンスが呼ばれたことのコールバックメソッド
+        /// </summary>
+        protected virtual void BeforeFirstGetterCalling()
+        {
+        }
+
+        private void OnDestroy()
+        {
+            // baseクラスでOnDestroy()を使用した場合、子クラスで使えなくなってしまうため
+            // OnDestroyと同時に呼ばれる代替メソッドを呼ぶ
+            BeforeOnDestroy();
+            
+            // シングルトンパターンでは、インスタンスの寿命は自分で管理する必要がある。
+            // ゲームオブジェクトが削除された時、シングルトンコンポーネントのインスタンスも自分で消す
+            instance = null;
+        }
+        
+        /// <summary>
+        /// OnDestroyの代替メソッド
+        /// </summary>
+        protected abstract void BeforeOnDestroy();
+}

--- a/Assets/Scripts/Utility/MonoSingleton.cs.meta
+++ b/Assets/Scripts/Utility/MonoSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 620961c7734bd4658bb02e4a60527222
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utility/ResourceMonoSingleton.cs
+++ b/Assets/Scripts/Utility/ResourceMonoSingleton.cs
@@ -1,0 +1,96 @@
+using System;
+using UnityEngine;
+
+namespace Utility
+{
+    public abstract class ResourceMonoSingleton<T>:MonoBehaviour where T:ResourceMonoSingleton<T>
+    {
+        /// <summary>
+        /// 唯一のインスタンス
+        /// </summary>
+        private static T instance;
+
+        /// <summary>
+        /// シングルトンなインスタンスを取得
+        /// </summary>
+        /// <exception cref="Exception"></exception>
+        public static T Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    // instanceがnullの場合、唯一のインスタンスを探す
+
+                    // シーンに存在する全てのTのインスタンスを探す
+                    var instances = FindObjectsOfType<T>();
+                    
+                    // 見つけたTのインスタンスの数で場合わけ
+                    instance = instances.Length switch
+                    {
+                        // インスタンスが存在しない場合、Resources内のプレハブを探す
+                        0 => CreatePrefabInstance(),
+                        
+                        // 唯一である場合、それを返す
+                        1 => instances[0],
+                        
+                        // 複数ある場合、シングルトンの制約に反しているため例外を投げる
+                        _ => throw new Exception($"{typeof(T)}のインスタンスがシーン上に複数存在します。"),
+                    };
+
+                    // 見つけた唯一のインスタンスを返す
+                    instance.BeforeFirstGetterCalling();
+                }
+
+                return instance;
+            }
+        }
+
+        /// <summary>
+        /// 現在のシーンにTのインスタンスがない場合
+        /// ResourcesからTのプレハブをロードしインスタンス化する
+        /// </summary>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        private static T CreatePrefabInstance()
+        {
+            // Tのコンポーネントを持つ全てのプレハブを取得
+            var prefabs = Resources.LoadAll<T>("");
+            
+            // 取得したプレハブが唯一出ない場合は例外を投げる (どれをインスタンス化すれば良いかわからないため)
+            var prefab = prefabs.Length switch
+            {
+                0 => throw new Exception($"{typeof(T)}のプレハブがResourcesフォルダに存在しません。"),
+                1 => prefabs[0],
+                _ => throw new Exception($"{typeof(T)}のプレハブがResourcesフォルダに複数存在します。"),
+            };
+
+            // 唯一のプレハブをインスタンス化して返す
+            return Instantiate(prefab);
+        }
+
+        /// <summary>
+        /// 初めてインスタンスが呼ばれたことのコールバックメソッド
+        /// </summary>
+        protected virtual void BeforeFirstGetterCalling()
+        {
+        }
+
+        private void OnDestroy()
+        {
+            // baseクラスでOnDestroy()を使用した場合、子クラスで使えなくなってしまうため
+            // OnDestroyと同時に呼ばれる代替メソッドを呼ぶ
+            BeforeOnDestroy();
+            
+            // シングルトンパターンでは、インスタンスの寿命は自分で管理する必要がある。
+            // ゲームオブジェクトが削除された時、シングルトンコンポーネントのインスタンスも自分で消す
+            instance = null;
+        }
+        
+        /// <summary>
+        /// OnDestroyの代替メソッド
+        /// </summary>
+        protected abstract void BeforeOnDestroy();
+
+    }
+}

--- a/Assets/Scripts/Utility/ResourceMonoSingleton.cs.meta
+++ b/Assets/Scripts/Utility/ResourceMonoSingleton.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 71f296cdcf17493a95a2fce0234b6fee
+timeCreated: 1702492585


### PR DESCRIPTION
# MonoBehaviour用のシングルトンクラス

### `MonoBehaviour<T>`
シーン上に必ずインスタンスが1つだけ存在することがわかっている場合に使用

### `ResourceMonoSingleton<T>`
シーン上に存在 or Resourcesフォルダ内に1つだけ存在することがわかっている場合に使用
(シーン上に見つかった場合はResourcesフォルダ内をチェックしない)