### PR TITLE
Get current time

### DIFF
--- a/Assets/Scripts/Game/TimeManager/TimeCalculator.cs
+++ b/Assets/Scripts/Game/TimeManager/TimeCalculator.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+
+public class TimeCalculator : MonoSingleton<TimeCalculator>
+{
+    [SerializeField] private AudioSource audioSource;
+
+    private RealTime_AudioTime_Relation real_audio_relation;
+
+    private void Start()
+    {
+        Stop();
+    }
+
+    /// <summary>
+    ///     楽曲を(続きから)再生する
+    /// </summary>
+    public void Play()
+    {
+        audioSource.Play();
+
+        // 再生のタイミングで、RealTimeとAudioTimeを関係づける
+        real_audio_relation = new RealTime_AudioTime_Relation(Time.realtimeSinceStartup, audioSource.time);
+    }
+
+    public void Stop()
+    {
+        audioSource.Stop();
+    }
+
+    /// <summary>
+    ///     現在の再生時刻を取得する
+    /// </summary>
+    /// <returns></returns>
+    public float GetTime()
+    {
+        return audioSource.time;
+    }
+
+    /// <summary>
+    ///     RealTimeからAudioSource.timeを導出する。
+    ///     具体的な用途は、FingerのlastTouchの時刻から、楽曲時間でいつ叩いたかを計算する
+    /// </summary>
+    /// <param name="beat_time_as_realtime"></param>
+    /// <returns></returns>
+    public float GetBeatTime(float beat_time_as_realtime)
+    {
+        return real_audio_relation.GetAudioTimeFromRealTime(beat_time_as_realtime);
+    }
+
+    /// <summary>
+    ///     Time.realtimeSinceStartup と AudioSource.time の関係
+    ///     両者の原点が異なるため、そのズレを保持している。
+    ///     具体的には、RealTime と AudioTimeは値は異なるが同じ時点を示すため、両者の差が原点のズレを表している。
+    /// </summary>
+    private struct RealTime_AudioTime_Relation
+    {
+        /// <summary>
+        ///     同じ時点を示すRealTimeとAudioTimeを引数にとるコンストラクタ
+        /// </summary>
+        /// <param name="realTime"></param>
+        /// <param name="audioTime"></param>
+        public RealTime_AudioTime_Relation(float realTime, float audioTime)
+        {
+            RealTime = realTime;
+            AudioTime = audioTime;
+        }
+
+        private float RealTime { get; }
+        private float AudioTime { get; }
+
+        /// <summary>
+        ///     RealTimeからAudioTimeに変換する
+        /// </summary>
+        /// <param name="realTime"></param>
+        /// <returns></returns>
+        public float GetAudioTimeFromRealTime(float realTime)
+        {
+            return AudioTime + realTime - RealTime;
+        }
+    }
+}

--- a/Assets/Scripts/Game/TimeManager/TimeCalculator.cs
+++ b/Assets/Scripts/Game/TimeManager/TimeCalculator.cs
@@ -1,81 +1,84 @@
 using UnityEngine;
 
-public class TimeCalculator : MonoSingleton<TimeCalculator>
+namespace Game
 {
-    [SerializeField] private AudioSource audioSource;
-
-    private RealTime_AudioTime_Relation real_audio_relation;
-
-    private void Start()
+    public class TimeCalculator : MonoSingleton<TimeCalculator>
     {
-        Stop();
-    }
+        [SerializeField] private AudioSource audioSource;
 
-    /// <summary>
-    ///     楽曲を(続きから)再生する
-    /// </summary>
-    public void Play()
-    {
-        audioSource.Play();
+        private RealTime_AudioTime_Relation real_audio_relation;
 
-        // 再生のタイミングで、RealTimeとAudioTimeを関係づける
-        real_audio_relation = new RealTime_AudioTime_Relation(Time.realtimeSinceStartup, audioSource.time);
-    }
-
-    public void Stop()
-    {
-        audioSource.Stop();
-    }
-
-    /// <summary>
-    ///     現在の再生時刻を取得する
-    /// </summary>
-    /// <returns></returns>
-    public float GetTime()
-    {
-        return audioSource.time;
-    }
-
-    /// <summary>
-    ///     RealTimeからAudioSource.timeを導出する。
-    ///     具体的な用途は、FingerのlastTouchの時刻から、楽曲時間でいつ叩いたかを計算する
-    /// </summary>
-    /// <param name="beat_time_as_realtime"></param>
-    /// <returns></returns>
-    public float GetBeatTime(float beat_time_as_realtime)
-    {
-        return real_audio_relation.GetAudioTimeFromRealTime(beat_time_as_realtime);
-    }
-
-    /// <summary>
-    ///     Time.realtimeSinceStartup と AudioSource.time の関係
-    ///     両者の原点が異なるため、そのズレを保持している。
-    ///     具体的には、RealTime と AudioTimeは値は異なるが同じ時点を示すため、両者の差が原点のズレを表している。
-    /// </summary>
-    private struct RealTime_AudioTime_Relation
-    {
-        /// <summary>
-        ///     同じ時点を示すRealTimeとAudioTimeを引数にとるコンストラクタ
-        /// </summary>
-        /// <param name="realTime"></param>
-        /// <param name="audioTime"></param>
-        public RealTime_AudioTime_Relation(float realTime, float audioTime)
+        private void Start()
         {
-            RealTime = realTime;
-            AudioTime = audioTime;
+            Stop();
         }
 
-        private float RealTime { get; }
-        private float AudioTime { get; }
+        /// <summary>
+        ///     楽曲を(続きから)再生する
+        /// </summary>
+        public void Play()
+        {
+            audioSource.Play();
+
+            // 再生のタイミングで、RealTimeとAudioTimeを関係づける
+            real_audio_relation = new RealTime_AudioTime_Relation(Time.realtimeSinceStartup, audioSource.time);
+        }
+
+        public void Stop()
+        {
+            audioSource.Stop();
+        }
 
         /// <summary>
-        ///     RealTimeからAudioTimeに変換する
+        ///     現在の再生時刻を取得する
         /// </summary>
-        /// <param name="realTime"></param>
         /// <returns></returns>
-        public float GetAudioTimeFromRealTime(float realTime)
+        public float GetTime()
         {
-            return AudioTime + realTime - RealTime;
+            return audioSource.time;
+        }
+
+        /// <summary>
+        ///     RealTimeからAudioSource.timeを導出する。
+        ///     具体的な用途は、FingerのlastTouchの時刻から、楽曲時間でいつ叩いたかを計算する
+        /// </summary>
+        /// <param name="beat_time_as_realtime"></param>
+        /// <returns></returns>
+        public float GetBeatTime(float beat_time_as_realtime)
+        {
+            return real_audio_relation.GetAudioTimeFromRealTime(beat_time_as_realtime);
+        }
+
+        /// <summary>
+        ///     Time.realtimeSinceStartup と AudioSource.time の関係
+        ///     両者の原点が異なるため、そのズレを保持している。
+        ///     具体的には、RealTime と AudioTimeは値は異なるが同じ時点を示すため、両者の差が原点のズレを表している。
+        /// </summary>
+        private struct RealTime_AudioTime_Relation
+        {
+            /// <summary>
+            ///     同じ時点を示すRealTimeとAudioTimeを引数にとるコンストラクタ
+            /// </summary>
+            /// <param name="realTime"></param>
+            /// <param name="audioTime"></param>
+            public RealTime_AudioTime_Relation(float realTime, float audioTime)
+            {
+                RealTime = realTime;
+                AudioTime = audioTime;
+            }
+
+            private float RealTime { get; }
+            private float AudioTime { get; }
+
+            /// <summary>
+            ///     RealTimeからAudioTimeに変換する
+            /// </summary>
+            /// <param name="realTime"></param>
+            /// <returns></returns>
+            public float GetAudioTimeFromRealTime(float realTime)
+            {
+                return AudioTime + realTime - RealTime;
+            }
         }
     }
 }

--- a/Assets/Scripts/Game/TimeManager/TimeCalculator.cs.meta
+++ b/Assets/Scripts/Game/TimeManager/TimeCalculator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d5621bee60ac4060b38669ae9d3d420
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# RealTime と AudioSource.time を計算するクラス

音ゲーで本当に必要な時刻は「今楽曲は何秒か」である一方、AudioSource.time だけでは精度が出ないことがある。
というのも、AudioSource.time を呼べるのはフレームレートの頻度だからである。

そのためEnhancedTouchを用いて、今のタッチはRealTimeで何秒かを取得する。こちらはポーリングにより実際のフレームレートより精度が良い。ただ必要なのは楽曲時間なので、AudioSource.timeから変換する必要がある。

このPRではこの変換を行うクラスを追加している