### PR TITLE
Field note manager

### DIFF
--- a/Assets/Resources/Game/note.prefab
+++ b/Assets/Resources/Game/note.prefab
@@ -97,3 +97,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cc5976cf7f23d44a99cdd4e2611270d1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  noteSprite: {fileID: 1491252417119480135}

--- a/Assets/Scripts/Game/Field/FieldNoteManager.cs
+++ b/Assets/Scripts/Game/Field/FieldNoteManager.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using UnityEngine.InputSystem.EnhancedTouch;
 
 namespace Game
@@ -10,15 +7,14 @@ namespace Game
     {
         public HashSet<NoteController> ControllersOnField { get; } = new();
 
-       
-        
+
         private void Update()
         {
             RemoveOverlookedNote();
         }
 
         /// <summary>
-        /// ノーツがMissの時間外かつ画面外に出た時、そのノーツを削除する
+        ///     ノーツがMissの時間外かつ画面外に出た時、そのノーツを削除する
         /// </summary>
         private void RemoveOverlookedNote()
         {
@@ -28,39 +24,39 @@ namespace Game
             {
                 // 本来叩くべき時間からのズレを計算 (このプロジェクトでは、遅い場合に負の数になるよう統一している)
                 var delta = noteController.Properties.Plan.BeatTime - time;
-                
+
                 // deltaは遅いときに負なので、マイナスをつけて正にする。
                 // Missの限界値より小さい時は削除しない
                 if (Settings.Instance.JudgeTime(JudgeEnum.Miss) > -delta) return false;
-                
+
                 // 画面内の場合は削除しない
                 if (noteController.NoteSprite.isVisible) return false;
-                
+
                 // 画面外かつMissの限界も超えたため削除対象
                 // 判定
                 noteController.Overlooked();
-                
+
                 return true;
             });
         }
 
         /// <summary>
-        /// プレイヤーInputがあった時、位置と時間的に最も適切なノーツを見つけ、Fingerを渡す
+        ///     プレイヤーInputがあった時、位置と時間的に最も適切なノーツを見つけ、Fingerを渡す
         /// </summary>
         /// <param name="finger"></param>
         public void SelectNoteForInput(Finger finger)
         {
             // タッチの位置からWorldPosに変換
-            var (beatPos,ok) = Field.Instance.ScreenToFieldPosition(finger.lastTouch.screenPosition);
+            var (beatPos, ok) = Field.Instance.ScreenToFieldPosition(finger.lastTouch.screenPosition);
 
             // タッチ位置がField上でない場合は何もしない
             if (!ok) return;
 
             // 判定すべきNoteControllerを探す
-            var target =TargetNoteFinder.Find(ControllersOnField,beatPos.x, (int)(finger.lastTouch.time * 1000));
-            
+            var target = TargetNoteFinder.Find(ControllersOnField, beatPos.x, (int)(finger.lastTouch.time * 1000));
+
             // 見つかればFingerを渡す
-            if (target != null)target.AddFinger(finger);
+            if (target != null) target.AddFinger(finger);
         }
     }
 }

--- a/Assets/Scripts/Game/Field/FieldNoteManager.cs
+++ b/Assets/Scripts/Game/Field/FieldNoteManager.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem.EnhancedTouch;
+
+namespace Game
+{
+    public class FieldNoteManager : MonoSingleton<FieldNoteManager>
+    {
+        public HashSet<NoteController> ControllersOnField { get; } = new();
+
+       
+        
+        private void Update()
+        {
+            RemoveOverlookedNote();
+        }
+
+        /// <summary>
+        /// ノーツがMissの時間外かつ画面外に出た時、そのノーツを削除する
+        /// </summary>
+        private void RemoveOverlookedNote()
+        {
+            var time = TimeCalculator.Instance.GetTime();
+
+            ControllersOnField.RemoveWhere(noteController =>
+            {
+                // 本来叩くべき時間からのズレを計算 (このプロジェクトでは、遅い場合に負の数になるよう統一している)
+                var delta = noteController.Properties.Plan.BeatTime - time;
+                
+                // deltaは遅いときに負なので、マイナスをつけて正にする。
+                // Missの限界値より小さい時は削除しない
+                if (Settings.Instance.JudgeTime(JudgeEnum.Miss) > -delta) return false;
+                
+                // 画面内の場合は削除しない
+                if (noteController.NoteSprite.isVisible) return false;
+                
+                // 画面外かつMissの限界も超えたため削除対象
+                // 判定
+                noteController.Overlooked();
+                
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// プレイヤーInputがあった時、位置と時間的に最も適切なノーツを見つけ、Fingerを渡す
+        /// </summary>
+        /// <param name="finger"></param>
+        public void SelectNoteForInput(Finger finger)
+        {
+            // タッチの位置からWorldPosに変換
+            var (beatPos,ok) = Field.Instance.ScreenToFieldPosition(finger.lastTouch.screenPosition);
+
+            // タッチ位置がField上でない場合は何もしない
+            if (!ok) return;
+
+            // 判定すべきNoteControllerを探す
+            var target =TargetNoteFinder.Find(ControllersOnField,beatPos.x, (int)(finger.lastTouch.time * 1000));
+            
+            // 見つかればFingerを渡す
+            if (target != null)target.AddFinger(finger);
+        }
+    }
+}

--- a/Assets/Scripts/Game/Field/FieldNoteManager.cs.meta
+++ b/Assets/Scripts/Game/Field/FieldNoteManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a97ae22b6160c42b2b962f6f5d52b420
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Field/FieldNoteManagerTest.meta
+++ b/Assets/Scripts/Game/Field/FieldNoteManagerTest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33fb02b1a546c4a3098c3729cc3e1cc5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Field/FieldNoteManagerTest/FieldNoteManagerTestScene.unity
+++ b/Assets/Scripts/Game/Field/FieldNoteManagerTest/FieldNoteManagerTestScene.unity
@@ -1,0 +1,723 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.4439372, g: 0.49315345, b: 0.5721989, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &29393229
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 251456807091927460, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_Name
+      value: note
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8362579003494630250, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1c31a534eda8f46aba665d865dbba7f9, type: 3}
+--- !u!1001 &105140412
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 4.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.9396927
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.3420201
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5664120568241422285, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7503414685907711331, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+      propertyPath: m_Name
+      value: Main Camera
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 82d79d67ddf9c4e6e816e00022c87a01, type: 3}
+--- !u!1001 &134021829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1093174382974262191, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_Layer
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4198629615589961821, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4234016393987636617, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6525952697886737408, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7415003838773283992, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_Name
+      value: Field
+      objectReference: {fileID: 0}
+    - target: {fileID: 7415003838773283992, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9195719507540552318, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      propertyPath: m_Layer
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 7415003838773283992, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 134021831}
+  m_SourcePrefab: {fileID: 100100000, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+--- !u!1 &134021830 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7415003838773283992, guid: 9b550e2224a0541dc89419753c08e6b9, type: 3}
+  m_PrefabInstance: {fileID: 134021829}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &134021831
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 134021830}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a97ae22b6160c42b2b962f6f5d52b420, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &553558860
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 553558863}
+  - component: {fileID: 553558862}
+  - component: {fileID: 553558861}
+  m_Layer: 0
+  m_Name: TimeCalculator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!82 &553558861
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 553558860}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+--- !u!114 &553558862
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 553558860}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5d5621bee60ac4060b38669ae9d3d420, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &553558863
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 553558860}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1245004222
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1245004224}
+  - component: {fileID: 1245004223}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1245004223
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245004222}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ff010c3265184d3899392661b027d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sampleGameInfo:
+    musicId: 13
+    blockNumber: 4
+    course: 0
+    isAuto: 0
+    isTutorial: 0
+--- !u!4 &1245004224
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245004222}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1336566214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1336566216}
+  - component: {fileID: 1336566215}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1336566215
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336566214}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1336566216
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336566214}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1341811548
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1341811550}
+  m_Layer: 0
+  m_Name: TestScript
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1341811550
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1341811548}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1850748280
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1850748283}
+  - component: {fileID: 1850748282}
+  - component: {fileID: 1850748281}
+  m_Layer: 0
+  m_Name: NoteGenerator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1850748281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1850748280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5bcb09abb39554711adc16d338a3066d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1850748282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1850748280}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7dc3e9793ae3c446cb656f2ac15fc4cb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  audioSource: {fileID: 553558861}
+  log: 
+--- !u!4 &1850748283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1850748280}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.53797096, y: -10.618466, z: 2.0982609}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 1336566216}
+  - {fileID: 553558863}
+  - {fileID: 1341811550}
+  - {fileID: 1245004224}
+  - {fileID: 134021829}
+  - {fileID: 29393229}
+  - {fileID: 105140412}
+  - {fileID: 1850748283}

--- a/Assets/Scripts/Game/Field/FieldNoteManagerTest/FieldNoteManagerTestScene.unity.meta
+++ b/Assets/Scripts/Game/Field/FieldNoteManagerTest/FieldNoteManagerTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 200dcc689584745e1a81da1e50e2ca0c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Field/TargetNoteFinder.cs
+++ b/Assets/Scripts/Game/Field/TargetNoteFinder.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem.EnhancedTouch;
+
+namespace Game
+{
+    public static class TargetNoteFinder
+    {
+         /// <summary>
+        /// 位置と時間的に最も適切なノーツを見つける
+        /// </summary>
+        /// <param name="finger"></param>
+        public static NoteController Find(HashSet<NoteController> controllersOnField,float posX, int beatTime)
+        {
+
+            // 今回のタッチに対し、最適なターゲットを探し、この変数に代入していく
+            NoteController target = null;
+            
+            // 各ノーツに対し、判定対象として適切か否かを表す「Score」を計算する
+            // 上記targetのScoreをここに保持する(値が小さいほどより適切)
+            var minScore = float.MaxValue;
+
+            foreach (var note in controllersOnField)
+            {
+                var plan = note.Properties.Plan;
+
+                // 位置ズレ、時間ズレを計算
+                var gapPosX = note.Trn.position.x - posX;
+                var gapTime = plan.BeatTime - beatTime;
+
+                // あまりにもズレが大きい場合は無視する
+                var x_threshold = (Settings.Instance.NoteTapTolerance + 1) / 2;
+                var time_threshold = Settings.Instance.JudgeTime(JudgeEnum.Miss);
+                if(Mathf.Abs(gapPosX)>x_threshold || Mathf.Abs(gapTime)>time_threshold) continue;
+                
+                // このノーツを判定すべきかを表すScoreを計算
+                var score = gapTime * gapTime + (float)(gapPosX * gapPosX * 0.25e6);
+
+                if (note.Properties.State is NoteController_Slide)
+                {
+                    // このノーツがスライド中の場合 (つまり持ち替え操作の場合)
+                    // 大きくハンデをつける。
+                    // (持ち替えの失敗より、ノーツを見逃すことの方が圧倒的に痛いため)
+                    score += (float)1e8;
+                }
+
+                // scoreが現在の最小値を下回った時
+                if (score < minScore)
+                {
+                    // 判定対象を更新する
+                    minScore = score;
+                    target = note;
+                }
+            }
+
+            return target;
+        }
+    }
+}

--- a/Assets/Scripts/Game/Field/TargetNoteFinder.cs
+++ b/Assets/Scripts/Game/Field/TargetNoteFinder.cs
@@ -1,21 +1,19 @@
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.InputSystem.EnhancedTouch;
 
 namespace Game
 {
     public static class TargetNoteFinder
     {
-         /// <summary>
-        /// 位置と時間的に最も適切なノーツを見つける
+        /// <summary>
+        ///     位置と時間的に最も適切なノーツを見つける
         /// </summary>
         /// <param name="finger"></param>
-        public static NoteController Find(HashSet<NoteController> controllersOnField,float posX, int beatTime)
+        public static NoteController Find(HashSet<NoteController> controllersOnField, float posX, int beatTime)
         {
-
             // 今回のタッチに対し、最適なターゲットを探し、この変数に代入していく
             NoteController target = null;
-            
+
             // 各ノーツに対し、判定対象として適切か否かを表す「Score」を計算する
             // 上記targetのScoreをここに保持する(値が小さいほどより適切)
             var minScore = float.MaxValue;
@@ -31,8 +29,8 @@ namespace Game
                 // あまりにもズレが大きい場合は無視する
                 var x_threshold = (Settings.Instance.NoteTapTolerance + 1) / 2;
                 var time_threshold = Settings.Instance.JudgeTime(JudgeEnum.Miss);
-                if(Mathf.Abs(gapPosX)>x_threshold || Mathf.Abs(gapTime)>time_threshold) continue;
-                
+                if (Mathf.Abs(gapPosX) > x_threshold || Mathf.Abs(gapTime) > time_threshold) continue;
+
                 // このノーツを判定すべきかを表すScoreを計算
                 var score = gapTime * gapTime + (float)(gapPosX * gapPosX * 0.25e6);
 

--- a/Assets/Scripts/Game/Field/TargetNoteFinder.cs.meta
+++ b/Assets/Scripts/Game/Field/TargetNoteFinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5aa3d91474aa43a288192b270a9c7ee1
+timeCreated: 1702664076

--- a/Assets/Scripts/Game/NoteController/NoteController.cs
+++ b/Assets/Scripts/Game/NoteController/NoteController.cs
@@ -1,3 +1,4 @@
+using System;
 using Game.Plan;
 using UnityEngine;
 using UnityEngine.InputSystem.EnhancedTouch;
@@ -6,8 +7,15 @@ namespace Game
 {
     public class NoteController : MonoBehaviour
     {
+        [SerializeField] private SpriteRenderer noteSprite;
+        
         private Transform trn;
 
+        /// <summary>
+        /// NoteControllerの画像コンポーネント
+        /// </summary>
+        public SpriteRenderer NoteSprite => noteSprite;
+        
         /// <summary>
         ///     NoteControllerのプロパティを集めたクラス
         ///     Poolに返された時、全てのプロパティをリセットする
@@ -88,7 +96,7 @@ namespace Game
             if (Properties.State is not NoteController_Move) return;
 
             // 子ノーツの有無で場合わけ
-            if (Properties.Plan.ChildNote != null)
+            if (Properties.Plan.ChildPlan != null)
             {
                 // 存在している時はスライド状態
                 Properties.ChangeState(this, MoveSlide);
@@ -99,6 +107,14 @@ namespace Game
                 OnReturn();
                 Debug.Log("デバッグのため、OnReturn");
             }
+        }
+
+        /// <summary>
+        /// 見逃されたため、強制Miss
+        /// </summary>
+        public void Overlooked()
+        {
+            OnReturn();
         }
 
         /// <summary>
@@ -118,6 +134,9 @@ namespace Game
         public void OnReturn()
         {
             Properties.Clear(this);
+            ReturnToPool();
         }
+        
+        public Action ReturnToPool { get; set; }
     }
 }

--- a/Assets/Scripts/Game/NoteController/NoteController.cs
+++ b/Assets/Scripts/Game/NoteController/NoteController.cs
@@ -8,14 +8,14 @@ namespace Game
     public class NoteController : MonoBehaviour
     {
         [SerializeField] private SpriteRenderer noteSprite;
-        
+
         private Transform trn;
 
         /// <summary>
-        /// NoteControllerの画像コンポーネント
+        ///     NoteControllerの画像コンポーネント
         /// </summary>
         public SpriteRenderer NoteSprite => noteSprite;
-        
+
         /// <summary>
         ///     NoteControllerのプロパティを集めたクラス
         ///     Poolに返された時、全てのプロパティをリセットする
@@ -48,6 +48,8 @@ namespace Game
                 return trn;
             }
         }
+
+        public Action ReturnToPool { get; set; }
 
         private void Update()
         {
@@ -110,7 +112,7 @@ namespace Game
         }
 
         /// <summary>
-        /// 見逃されたため、強制Miss
+        ///     見逃されたため、強制Miss
         /// </summary>
         public void Overlooked()
         {
@@ -136,7 +138,5 @@ namespace Game
             Properties.Clear(this);
             ReturnToPool();
         }
-        
-        public Action ReturnToPool { get; set; }
     }
 }

--- a/Assets/Scripts/Game/NoteController/Pool/NotePool.cs
+++ b/Assets/Scripts/Game/NoteController/Pool/NotePool.cs
@@ -1,4 +1,3 @@
-using Game;
 using UniRx;
 using UniRx.Toolkit;
 using UnityEngine;
@@ -23,9 +22,9 @@ namespace Game
         {
             var prefab = Resources.Load<NoteController>("Game/note");
             var controller = Object.Instantiate(prefab, NoteParent);
-            
+
             // 自身をプールに返すメソッドを設定
-            controller.ReturnToPool = () => this.Return(controller);
+            controller.ReturnToPool = () => Return(controller);
             return controller;
         }
     }

--- a/Assets/Scripts/Game/NoteController/Pool/NotePool.cs
+++ b/Assets/Scripts/Game/NoteController/Pool/NotePool.cs
@@ -22,7 +22,11 @@ namespace Game
         protected override NoteController CreateInstance()
         {
             var prefab = Resources.Load<NoteController>("Game/note");
-            return Object.Instantiate(prefab, NoteParent);
+            var controller = Object.Instantiate(prefab, NoteParent);
+            
+            // 自身をプールに返すメソッドを設定
+            controller.ReturnToPool = () => this.Return(controller);
+            return controller;
         }
     }
 }

--- a/Assets/Scripts/Game/NoteController/State/NoteController_Slide.cs
+++ b/Assets/Scripts/Game/NoteController/State/NoteController_Slide.cs
@@ -29,7 +29,7 @@ namespace Game
             var currentPos = noteController.Trn.position;
 
             // 子ノーツの振る舞い
-            var childPlan = noteController.Properties.Plan.ChildNote;
+            var childPlan = noteController.Properties.Plan.ChildPlan;
 
             // スライド開始時刻
             startTime = noteController.Properties.Plan.BeatTime;

--- a/Assets/Scripts/Game/NoteGenerator/NoteGenerator.cs
+++ b/Assets/Scripts/Game/NoteGenerator/NoteGenerator.cs
@@ -56,13 +56,15 @@ namespace Game
             // 発射
             controller.Launch();
 
+            FieldNoteManager.Instance.ControllersOnField.Add(controller);
+
 #if UNITY_EDITOR
             // デバッグしやすいように、オブジェクトの名前としてPlanを設定
             controller.name = $"{plan}";
 #endif
 
             // 子ノーツがあれば、それも射出する
-            if (plan.ChildNote is { } childPlan) Launch(childPlan);
+            if (plan.ChildPlan is { } childPlan) Launch(childPlan);
         }
     }
 }

--- a/Assets/Scripts/Game/Plan/NotePlan.cs
+++ b/Assets/Scripts/Game/Plan/NotePlan.cs
@@ -45,21 +45,36 @@ namespace Game.Plan
         ///     子ノーツのPlan
         ///     nullの時は通常のーつ
         /// </summary>
-        public NotePlan ChildNote { get; private set; }
+        public NotePlan ChildPlan { get; private set; }
+        
+        /// <summary>
+        ///     親ノーツのPlan
+        ///     nullの時は通常のーつ
+        /// </summary>
+        public NotePlan ParentPlan { get; private set; }
 
         /// <summary>
         ///     子ノーツを設定する
         /// </summary>
-        /// <param name="childId"></param>
-        public void SetChild(NotePlan childId)
+        /// <param name="childPlan"></param>
+        public void SetChild(NotePlan childPlan)
         {
-            ChildNote = childId;
+            ChildPlan = childPlan;
+        }
+        
+        /// <summary>
+        ///     親ノーツを設定する
+        /// </summary>
+        /// <param name="parentPlan"></param>
+        public void SetParent(NotePlan parentPlan)
+        {
+            ParentPlan = parentPlan;
         }
 
         public override string ToString()
         {
             return
-                $"noteId:{NoteId,4}\tbeatTime:{BeatTime,6}\tlaunchTime:{LaunchTime,6}\tblock:{Block}\tchildNote:{ChildNote,1}\tbpm:{Bpm}";
+                $"noteId:{NoteId,4}\tbeatTime:{BeatTime,6}\tlaunchTime:{LaunchTime,6}\tblock:{Block}\tchildNote:{ChildPlan,1}\tbpm:{Bpm}";
         }
     }
 }

--- a/Assets/Scripts/Game/Plan/NotePlan.cs
+++ b/Assets/Scripts/Game/Plan/NotePlan.cs
@@ -43,13 +43,11 @@ namespace Game.Plan
 
         /// <summary>
         ///     子ノーツのPlan
-        ///     nullの時は通常のーつ
         /// </summary>
         public NotePlan ChildPlan { get; private set; }
-        
+
         /// <summary>
         ///     親ノーツのPlan
-        ///     nullの時は通常のーつ
         /// </summary>
         public NotePlan ParentPlan { get; private set; }
 
@@ -61,7 +59,7 @@ namespace Game.Plan
         {
             ChildPlan = childPlan;
         }
-        
+
         /// <summary>
         ///     親ノーツを設定する
         /// </summary>

--- a/Assets/Scripts/Game/Plan/NotePlanConverter.cs
+++ b/Assets/Scripts/Game/Plan/NotePlanConverter.cs
@@ -52,6 +52,7 @@ namespace Game.Plan
                 {
                     var childPlan = CreatePlan(child);
                     parent.SetChild(childPlan);
+                    childPlan.SetParent(parent);
                     parent = childPlan;
                 }
             }

--- a/Assets/Scripts/Game/TimeManager/LaunchTimeManager.cs
+++ b/Assets/Scripts/Game/TimeManager/LaunchTimeManager.cs
@@ -60,8 +60,13 @@ namespace Game
         /// <param name="info">ゲーム設定</param>
         public void Initialize(GameInfo info)
         {
+            // 射出時間とnoteIdのペアを作りたい
             List<(int time, int noteId)> timesToNotify =
-                info.GetPlanMap().Select(n => (n.Value.LaunchTime, n.Value.NoteId)).ToList();
+                info.GetPlanMap() // NoteId NotePlanの辞書
+                    .Select(pair=>pair.Value) // Valueだけ取り出す
+                    .Where(plan=>plan.ParentPlan==null)// 親を持たないノーツに限定
+                    .Select(n => (n.LaunchTime, n.NoteId))// time, id のペアに変換
+                    .ToList(); // Listに変換
 
             // 射出時間順に並べ替え
             timesToNotify.Sort((a, b) => a.time - b.time);

--- a/Assets/Scripts/Game/TimeManager/LaunchTimeManager.cs
+++ b/Assets/Scripts/Game/TimeManager/LaunchTimeManager.cs
@@ -63,9 +63,9 @@ namespace Game
             // 射出時間とnoteIdのペアを作りたい
             List<(int time, int noteId)> timesToNotify =
                 info.GetPlanMap() // NoteId NotePlanの辞書
-                    .Select(pair=>pair.Value) // Valueだけ取り出す
-                    .Where(plan=>plan.ParentPlan==null)// 親を持たないノーツに限定
-                    .Select(n => (n.LaunchTime, n.NoteId))// time, id のペアに変換
+                    .Select(pair => pair.Value) // Valueだけ取り出す
+                    .Where(plan => plan.ParentPlan == null) // 親を持たないノーツに限定
+                    .Select(n => (n.LaunchTime, n.NoteId)) // time, id のペアに変換
                     .ToList(); // Listに変換
 
             // 射出時間順に並べ替え

--- a/Assets/Scripts/General/JudgeEnum.cs
+++ b/Assets/Scripts/General/JudgeEnum.cs
@@ -1,7 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-
 public enum JudgeEnum
 {
     None, // まだ判定されていない状態

--- a/Assets/Scripts/General/Settings.cs
+++ b/Assets/Scripts/General/Settings.cs
@@ -36,5 +36,40 @@ public class Settings : ScriptableObject
     
     // スライドの判定に対し左右にそれぞれ　(noteSlideTolerance / 2) の許容範囲を作る
     public float NoteSlideTolerance => noteSlideTolerance;
-    [SerializeField] private float noteSlideTolerance = 1f; 
+    [SerializeField] private float noteSlideTolerance = 1f;
+
+    [SerializeField] private int perfectThreshold = 40;
+    [SerializeField] private int goodThreshold = 100;
+    [SerializeField] private int missThreshold = 150;
+
+    /// <summary>
+    /// 各判定の閾値を取得
+    /// </summary>
+    /// <param name="judge"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public int JudgeTime(JudgeEnum judge)
+    {
+        return judge switch
+        {
+            JudgeEnum.Perfect => perfectThreshold,
+            JudgeEnum.Good => goodThreshold,
+            JudgeEnum.Miss => missThreshold,
+            _ => throw new ArgumentOutOfRangeException(nameof(judge), judge, null)
+        };
+    }
+
+    /// <summary>
+    /// ズレ時間から判定を算出
+    /// </summary>
+    /// <param name="gapTime"></param>
+    /// <returns></returns>
+    public JudgeEnum GetJudge(int gapTime)
+    {
+        gapTime = Mathf.Abs(gapTime);
+        if (gapTime < perfectThreshold) return JudgeEnum.Perfect;
+        else if (gapTime < goodThreshold) return JudgeEnum.Good;
+        else if (gapTime < missThreshold) return JudgeEnum.Miss;
+        else return JudgeEnum.None;
+    }
 }


### PR DESCRIPTION
# いくつかミスが発覚した

- NoteControllerは自身の画像を取得する必要がある。場外判定のisVisibleはSpriteRendererのプロパティ
- Planには子ノーツだけでなく自身の親を設定する必要がある。(親ノーツがある場合、LaunchTimeManagerは通知を送ってはいけない)
- NoteControllerにOverlookedメソッドが必要
- Poolに返す、ReturnToPoolActionを、インスタンス化の時に渡す

# FieldNoteManager

役割は3つ
- フィールド上の全てのノーツを保持する
- fingerから、判定すべきノーツを選択する
- 場外のノーツを削除する

# 判定の時刻を設定
Perfect ... 40 >
good ... 100 >
miss ... 150 >